### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Skill-Learn is an AI-powered multi-tenant LMS (Learning Management System) built as a **Turborepo monorepo** with npm workspaces. It contains two Next.js 16 apps and four shared packages.
+
+| Service        | Port | Description                       |
+|----------------|------|-----------------------------------|
+| LMS (`apps/lms`) | 3000 | Main user-facing + admin app (webpack) |
+| CMS (`apps/cms`) | 3001 | Super-admin dashboard (Turbopack)       |
+
+### Quick reference
+
+Standard commands are documented in the root `package.json`:
+
+- **Dev servers**: `npm run dev` (starts both LMS and CMS via Turborepo)
+- **Lint**: `npm run lint`
+- **Tests**: `npm test` (runs Vitest via Turborepo)
+- **Prisma generate**: `npm run prisma:generate` (must run after schema changes or fresh install)
+
+### Non-obvious caveats
+
+1. **Clerk authentication keys are required.** Without valid `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` in `apps/lms/.env.local` and `apps/cms/.env.local`, the dev servers will compile and serve pages, but the client-side Clerk SDK will redirect the browser to an error page. The publishable key must follow Clerk's format: `pk_test_<base64-encoded-frontend-api-url>`. Placeholder env files are auto-created during setup but require real Clerk credentials for full functionality.
+
+2. **MongoDB is required for data operations.** The Prisma client connects to MongoDB via `MONGODB_URI`. Without a real connection, API routes that access the database will fail at runtime, but the apps will still compile and start.
+
+3. **LMS uses `--webpack` flag** in its dev script (`next dev --webpack`), while CMS uses Turbopack. This is intentional; see the dev script in `apps/lms/package.json`.
+
+4. **Lint has pre-existing errors in LMS.** Running `npm run lint` exits non-zero due to ~23 ESLint errors and ~35 warnings in `apps/lms`. The CMS lint passes with only warnings.
+
+5. **The `next-intl` webpack cache warning** (`Parsing of .../format/index.js for build dependencies failed`) appears on every LMS compile and is harmless.
+
+6. **No Docker/devcontainer** files exist. The project is designed for direct Node.js development or Vercel deployment.
+
+7. **Environment files** should be placed in each app directory (`apps/lms/.env.local`, `apps/cms/.env.local`), not in the workspace root. Next.js loads `.env.local` from the app's working directory.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future cloud agents working on this repository.

### What's included

- Overview of the monorepo structure (LMS on port 3000, CMS on port 3001)
- Quick reference for standard commands (`npm run dev`, `npm run lint`, `npm test`, `npm run prisma:generate`)
- Non-obvious caveats discovered during environment setup:
  - Clerk authentication keys format requirements
  - MongoDB connection requirements
  - LMS webpack vs CMS Turbopack distinction
  - Pre-existing lint errors in LMS
  - Harmless next-intl webpack cache warning
  - Environment file placement (per-app, not root)

### Environment verification

The development environment was verified with the following results:

| Check | Result |
|-------|--------|
| `npm install` | 889 packages installed |
| `npm run prisma:generate` | Prisma Client v6.19.2 generated |
| `npm test` | 16/16 tests passed (5 test files) |
| `npm run lint` | CMS passes (warnings only); LMS has pre-existing errors |
| `npm run dev` | Both servers start and serve pages |
| LMS `localhost:3000` | 200 OK (redirects to /en with locale) |
| CMS `localhost:3001` | 200 OK on /cms/sign-in |

[LMS dev server running - Clerk redirect with placeholder keys](https://cursor.com/agents/bc-52e237f1-ec70-405e-9664-610ba64b8caa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flms_clerk_redirect.webp)

Server verification logs:
[server_verification.log](https://cursor.com/agents/bc-52e237f1-ec70-405e-9664-610ba64b8caa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fserver_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52e237f1-ec70-405e-9664-610ba64b8caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52e237f1-ec70-405e-9664-610ba64b8caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

